### PR TITLE
Update CLI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM target/consensource-rust:cli-1.30
+FROM target/consensource-rust:cli-stable
 
 COPY . /cli
 WORKDIR cli


### PR DESCRIPTION
## Proposed change/fix

Update base image to `target/consensource-rust:cli-stable`

Resolves

```
error[E0658]: non-builtin inner attributes are unstable
 --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/protobuf-2.15.0/src/descriptor.rs:9:1
  |
9 | #![rustfmt::skip]
  | ^^^^^^^^^^^^^^^^^
  |
  = note: for more information, see https://github.com/rust-lang/rust/issues/54726
  = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
```

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`docker build -t target/consensource-cli:local .`
