### PR TITLE
Implement certificate assertion batch_create command

### DIFF
--- a/example_certificates.json
+++ b/example_certificates.json
@@ -1,14 +1,14 @@
 {
-  "certificate_id_1" : {
-    "asserter_organization_id": "asserter_org_id_1",
-    "factory_id": "factory_id_1",
+  "certificate_id_1": {
+    "asserter_organization_id": "asserter123",
+    "factory_id": "test_factory_id_1",
     "standard_id": "standard_id",
     "valid_from": "20201012",
     "valid_to": "20211012"
   },
-  "certificate_id_2" : {
-    "asserter_organization_id": "asserter_org_id_2",
-    "factory_id": "factory_id_2",
+  "certificate_id_2": {
+    "asserter_organization_id": "asserter123",
+    "factory_id": "test_factory_id_2",
     "standard_id": "standard_id",
     "valid_from": "20201012",
     "valid_to": "20211012"

--- a/example_certificates.json
+++ b/example_certificates.json
@@ -1,0 +1,16 @@
+{
+  "certificate_id_1" : {
+    "asserter_organization_id": "asserter_org_id_1",
+    "factory_id": "factory_id_1",
+    "standard_id": "standard_id",
+    "valid_from": "20201012",
+    "valid_to": "20211012"
+  },
+  "certificate_id_2" : {
+    "asserter_organization_id": "asserter_org_id_2",
+    "factory_id": "factory_id_2",
+    "standard_id": "standard_id",
+    "valid_from": "20201012",
+    "valid_to": "20211012"
+  }
+}

--- a/example_factories.json
+++ b/example_factories.json
@@ -1,22 +1,24 @@
 {
-  "test_factory_id_1" : {
+  "test_factory_id_1": {
     "asserter_organization_id": "asserter123",
     "name": "Sword & Sheath Co.",
     "contact_name": "-",
     "contact_phone_number": "-",
     "contact_language_code": "-",
     "city": "Minas Tirith",
+    "state_province": "White Mountains",
     "country": "Gondor",
     "postal_code": "-",
     "street_address": "123 White Throne Boulevard, Gondor\n54123"
   },
-  "test_factory_id_2" : {
+  "test_factory_id_2": {
     "asserter_organization_id": "asserter123",
     "name": "Dwarvan Iron Inc.",
     "contact_name": "-",
     "contact_phone_number": "-",
     "contact_language_code": "-",
     "city": "Minas Morgul ",
+    "state_province": "Ephel Dúath",
     "country": "Gondor",
     "postal_code": "-",
     "street_address": "123 Isildur Drive, Gondor\n54321"

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,12 @@ fn parse_args<'a>() -> ArgMatches<'a> {
               (@arg key: -k --key +takes_value "Signing key name")
               (@arg url: --url +takes_value "URL to the ConsenSource REST API")
             )
+            (@subcommand batch_create =>
+              (about: "create a batch of certificate assertions")
+              (@arg filepath: +required "File path to read JSON data of certificates")
+              (@arg key: -k --key +takes_value "Signing key name")
+              (@arg url: --url +takes_value "URL to the ConsenSource REST API")
+            )
           )
           (@subcommand standard =>
             (about: "manage a standards assertion")


### PR DESCRIPTION
## Proposed change/fix

See title

- [x] Implement `csrc assertion certificate batch_create [OPTIONS] <filepath>` (very similar to the factory assertion batch_create command).
- [x] Renamed function `submit_factory_assertions_batch_list` to `submit_assertions_batch_list`

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

- [ ] @trevormcdonald testing locally w/ ingestion-service side implementation
