### PR TITLE
Change batch assertions to use one batch with many transactions instead of many batches

### DIFF
--- a/src/commands/assertion.rs
+++ b/src/commands/assertion.rs
@@ -2,7 +2,8 @@ use crate::error::CliError;
 use crate::key;
 use crate::submit;
 use crate::transaction::{
-    create_batch, create_batch_list, create_batch_list_from_one, create_batches, create_transaction,
+    create_batch, create_batch_list, create_batch_list_from_one, create_batch_with_transactions,
+    create_transaction,
 };
 
 use clap::ArgMatches;
@@ -219,8 +220,8 @@ fn run_factory_batch_create_command<'a>(args: &ArgMatches<'a>) -> Result<(), Cli
     }
 
     println!("Creating batch list for transactions");
-    let batches = create_batches(txn_list, &signer)?;
-    let batch_list = create_batch_list(batches);
+    let batch = create_batch_with_transactions(txn_list, &signer)?;
+    let batch_list = create_batch_list(vec![batch]);
 
     println!("Submitting batch list for processing");
     submit_assertions_batch_list(assertion_id, batch_list, url)
@@ -369,8 +370,8 @@ fn run_certificate_batch_create_command<'a>(args: &ArgMatches<'a>) -> Result<(),
     }
 
     println!("Creating batch list for transactions");
-    let batches = create_batches(txn_list, &signer)?;
-    let batch_list = create_batch_list(batches);
+    let batch = create_batch_with_transactions(txn_list, &signer)?;
+    let batch_list = create_batch_list(vec![batch]);
 
     println!("Submitting batch list for processing");
     submit_assertions_batch_list(assertion_id, batch_list, url)


### PR DESCRIPTION
## Proposed change/fix

- Change batch assertions to use one batch with many transactions instead of many batches
- Remove old `create_batches` function
- Update tests

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`cargo clippy`
`cargo test`
