### PR TITLE
Add organization batch update command

### DIFF
--- a/example_org_update.json
+++ b/example_org_update.json
@@ -1,0 +1,20 @@
+{
+  "test_factory_id_1": {
+    "name": "Bow & Arrow Co.",
+    "contact_name": "Bergil",
+    "contact_phone_number": "0118999881999111725",
+    "contact_language_code": "Westron",
+    "city": "Minas Tirith",
+    "country": "Gondor",
+    "street_address": "123 White Throne Boulevard, Gondor\n54123"
+  },
+  "test_factory_id_2": {
+    "name": "Dark Tower Inc.",
+    "contact_name": "Lammen Gorthaur",
+    "contact_phone_number": "3",
+    "contact_language_code": "Westron",
+    "city": "Barad-dur",
+    "country": "Mordor",
+    "street_address": "456 Orodruin Drive, Mordor\n54321"
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,12 @@ fn parse_args<'a>() -> ArgMatches<'a> {
                 (@arg key: -k --key +takes_value "Signing key name")
                 (@arg url: --url +takes_value "URL to the ConsenSource REST API")
             )
+            (@subcommand batch_update =>
+                (about: "create a batch of organization updates")
+                (@arg filepath: +required "File path to read JSON data of org updates")
+                (@arg key: -k --key +takes_value "Signing key name")
+                (@arg url: --url +takes_value "URL to the ConsenSource REST API")
+            )
         )
         (@subcommand certificate =>
             (about: "manage the certificate")


### PR DESCRIPTION
- Add run_batch_update_command to organizations that takes in a json file
- Add example update json file to be used in the same way as bulk assertion update

## Proposed change/fix

Describe your change/fix and tell us why we should accept it. Linking to the issue(s) is helpful too. If there is no outstanding issue, please create one in correspondence to this PR.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

Build new CLI image
```bash
docker build -t target/consensource-cli:latest .
```

### Update asserted factory organizations

1. Create an agent
```bash
 csrc agent create cliagent --url http://api:9009
```

2. Create an ingestion organization
```bash
csrc organization create assertororg 4 assertercontactname 7632918628 ENG --city minneapolis --country usa --street_address '821 thor street' --url http://api:9009
```

3. Make sure `example_factories.json` and `example_org_update.json` are present in your environment (with `docker cp` or `kubectl cp`).

4. Edit the `example_factories.json` file to set the ingestion organization id as the `asserter_organization_id` of both factories.

5. Add a batch of factory assertions
```bash
 csrc assertion factory batch_create example_factories.json --url http://api:9009
```

6. Perform a batch update of those factories with
```bash
csrc organization batch_update /example_org_update.json --url http://api:9009
``` 

7. Verify in db that the org, contact, and address were updated according to the json file.