### PR TITLE
Add certificate batch update command

### DIFF
--- a/example_cert_update.json
+++ b/example_cert_update.json
@@ -1,0 +1,12 @@
+{
+  "certificate_id_1": {
+    "certifying_body_id": "test_cert_body_id",
+    "valid_from": "20201013",
+    "valid_to": "20211013"
+  },
+  "certificate_id_2": {
+    "certifying_body_id": "test_cert_body_id",
+    "valid_from": "20201013",
+    "valid_to": "20211013"
+  }
+}

--- a/src/commands/assertion.rs
+++ b/src/commands/assertion.rs
@@ -309,12 +309,12 @@ fn run_certificate_batch_create_command(args: &ArgMatches) -> Result<(), CliErro
     let mut standard_id: &str;
     let mut assertion_id = String::from("");
 
-    // Read factories from provided JSON batch file
+    // Read certificates from provided JSON batch file
     let filepath = args.value_of("filepath").unwrap();
     let mut file = File::open(filepath)?;
     let mut data: String = String::new();
     file.read_to_string(&mut data)?;
-    let factories: serde_json::Value = serde_json::from_str(&data).expect("Unable to parse");
+    let certificates: serde_json::Value = serde_json::from_str(&data).expect("Unable to parse");
 
     // Create signing key
     let private_key = key::load_signing_key(key)?;
@@ -322,10 +322,10 @@ fn run_certificate_batch_create_command(args: &ArgMatches) -> Result<(), CliErro
     let factory = signing::CryptoFactory::new(&*context);
     let signer = factory.new_signer(&private_key);
 
-    // Loop through map of factories and populate list of transactions
+    // Loop through map of certificates and populate list of transactions
     println!("Creating transactions for {}", filepath);
     let mut txn_list: Vec<Transaction> = vec![];
-    for (key, value) in factories.as_object().unwrap() {
+    for (key, value) in certificates.as_object().unwrap() {
         // Gather information and initialize defined variables from above
         certificate_id = key.as_str();
         asserter_organization_id = value

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,13 @@ fn parse_args<'a>() -> ArgMatches<'a> {
                 (@arg cert_data: -cd --cert_data +takes_value +multiple "Optional cert data")
                 (@arg key: -k --key +takes_value "Signing key name")
                 (@arg url: --url +takes_value "URL to the ConsenSource REST API")
-          )
+            )
+            (@subcommand batch_update =>
+              (about: "update a batch of certificates")
+              (@arg filepath: +required "File path to read JSON data of certificate updates")
+              (@arg key: -k --key +takes_value "Signing key name")
+              (@arg url: --url +takes_value "URL to the ConsenSource REST API")
+            )
         )
         (@subcommand standard =>
             (about: "manage standards")


### PR DESCRIPTION
## Proposed change/fix

- Add run_batch_update_command to organizations that takes in a json file
- Add example update json file to be used in the same way as bulk assertion update
- Update update_certificate_payload function to return payload instead of resut containing payload
- Fix typos in `commands/assertions.rs`

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

Build new CLI image
```bash
docker build -t target/consensource-cli:latest .
```

### Update asserted certificates

1. Create an agent
```bash
 csrc agent create cliagent --url http://api:9009
```

2. Create an ingestion organization
```bash
csrc organization create assertororg 4 assertercontactname 7632918628 ENG --city minneapolis --country usa --street_address '821 thor street' --url http://api:9009
```

3. Create a factory assertion
```
csrc assertion factory create {ingestion_org_id_here} testfactoryassertion1 yuki 6123982765 JPN --city osaka --country japan --street_address 'fukuoka south st' --state_province kanto --postal_code 55414 --url http://api:9009
```

4. Create a standard assertion
```
csrc assertion standard create {ingestion_org_id_here} test_standard 1 'my standard' 'target.com' 20211015 --url http://api:9009
```

5. Create 2 certificate assertions
```
csrc assertion certificate create {ingestion_org_id_here} {factory_org_id_here} 20201012 20201012 {standard_org_id_here} --url http://api:9009 
```

```
csrc assertion certificate create {ingestion_org_id_here} {factory_org_id_here} 20201012 20201012 {standard_org_id_here} --url http://api:9009 
```

6. Make sure `example_cert_update.json` is present in your container (with `docker cp` or `kubectl cp`).

7. Edit the `example_cert_update.json` file to replace `certificate_id_1` and `certificate_id_2` with the generated certificate ids, and then the ingestion organization id as the `certifying_body_id` of both certificates.

8. Batch update certificates
```
csrc certificate batch_update example_cert_update.json --url http://api:9009
```

9. Verify in db that the certificates were updated.
